### PR TITLE
Added a custom variable to toggle phonetic symbols

### DIFF
--- a/guess-word.el
+++ b/guess-word.el
@@ -48,9 +48,9 @@
   :group 'guess-word
   :type 'list)
 
-(defcustom guess-word-show-pronounciation
+(defcustom guess-word-show-pronunciation
   nil
-  "Show pronounciation of word if it exists in dictionary when non-nil."
+  "Show pronunciation of word if it exists in dictionary when non-nil."
   :group 'guess-word
   :type 'boolean)
 
@@ -186,7 +186,7 @@
       (forward-line line)
       (if (guess-word-esl-line-p (thing-at-point 'line t))
           (let ((line (thing-at-point 'line t)))
-            (if guess-word-show-pronounciation
+            (if guess-word-show-pronunciation
                 line
               (replace-regexp-in-string "\\[.*?\] " "" line 'fixedcase nil)))
         (guess-word-extract-word)))))

--- a/guess-word.el
+++ b/guess-word.el
@@ -48,7 +48,13 @@
   :group 'guess-word
   :type 'list)
 
-(defvar-local guess-word-mask-condition 'oddp)
+(defcustom guess-word-show-pronounciation
+  nil
+  "Show pronounciation of word if it exists in dictionary when non-nil."
+  :group 'guess-word
+  :type 'boolean)
+
+(defvar-local guess-word-mask-condition 'cl-oddp)
 (defvar-local guess-word-total 0)
 (defvar-local guess-word-score 0)
 
@@ -179,7 +185,10 @@
     (let ((line (random (line-number-at-pos (point-max)))))
       (forward-line line)
       (if (guess-word-esl-line-p (thing-at-point 'line t))
-          (thing-at-point 'line t)
+          (let ((line (thing-at-point 'line t)))
+            (if guess-word-show-pronounciation
+                line
+              (replace-regexp-in-string "\\[.*?\] " "" line 'fixedcase nil)))
         (guess-word-extract-word)))))
 
 (defvar guess-word-mode-map (make-sparse-keymap)


### PR DESCRIPTION
背单词的时候下面的国际音标给了很强的提示。如果`guess-word-show-pronunciation`是`nil`，则通过regexp匹配方括号去除国际音标。